### PR TITLE
modified create-dir-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ The documentation for the analyses performed and the code can be found [here](ht
 Install and Use
 ---------------
 Use git to checkout the current copy of this suite
-# From the project directory create the directories that will hold working files during execution and the final test results.
+From the project directory create the directories that will hold working files during execution and the final test results.
 
 $testhost ~/sards$ experiments/create-dir-script
 
-# Modify the makefile as necessary and compile the code
+Modify the makefile as necessary and compile the code
 
-# Run the the assess executable passing in a stream of binary data.
+Run the the assess executable passing in a stream of binary data.
 $testhost ~/sards$ cat /dev/urandom | ./assess
 
-# the program will produce output similar to the following for an mp4 file
+Output produced for a non-random data set, such as for and .mp4 here, will be similar to following:
 0.0%     4/10   *  Frequency
 0.0%     4/10   *  BlockFrequency
 0.0%     4/10   *  CumulativeSums
@@ -44,7 +44,7 @@ $testhost ~/sards$ cat /dev/urandom | ./assess
 20.8%     3/10   *  Serial
 
 
-# and the following for a random data set such as /dev/urandom
+and the following for a random data set such as /dev/urandom
 90.0%     6/10   *  ApproximateEntropy
 91.3%     6/10   *  ApproximateEntropy
 93.9%     7/10   *  ApproximateEntropy

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# sards
+Statistical Analaysis of Random Data Sets
+=========================================
+
+This project was developed to quickly compare variously generated sets of random data as to their relative quality of randomness to one another. It is based on the NIST sts-2.1.2 battery of statistical evaluations.  Data is passed in via a pipe and is broken into 10 streams( or batches) of 100000 bits each.  Each stream is then passed through the battery of tests.  As the test runs an overall passing rate of batches is calculated.  Ouput is produced when a test batch does not achieve a ratio of passes > 7 out of 10 for a given test. When this failure is detected a line is produced to the screen displaying A) the overall pass rate of all test batches, B) the ratio of passes to batch size for the failing test and C) the name of the test that failed for the batch. 
+
+NOTE:  All tests from the battery are executed over the incoming data stream, however, the results from Universal test and the NonOverlapping test are currently being discarded for a couple of reasons.  The Universal test is failing for every data stream passed into the unmodified sts-2.1.2 suite and consequently our modification.  The NonOverlapping test produces multiple evaluations over the same batch of streams and therefore skews our results.
+
+DISCLAIMER!   The original suite was menu driven and not conducive to quick and flexible execution. This work is, to put it mildly a hack job of an apparent hack job, based on the sts-2.1.2 test suite from NIST.  Precedence was given to speed of development not to quality of code.  
+
+The original sts-2.1.2 suite is available from NIST [here](http://csrc.nist.gov/groups/ST/toolkit/rng/documentation_software.html). 
+The documentation for the analyses performed and the code can be found [here](http://csrc.nist.gov/publications/nistpubs/800-22-rev1a/SP800-22rev1a.pdf).
+
+
+
+
+Install and Use
+---------------
+Use git to checkout the current copy of this suite
+# From the project directory create the directories that will hold working files during execution and the final test results.
+
+$testhost ~/sards$ experiments/create-dir-script
+
+# Modify the makefile as necessary and compile the code
+
+# Run the the assess executable passing in a stream of binary data.
+$testhost ~/sards$ cat /dev/urandom | ./assess
+
+# the program will produce output similar to the following for an mp4 file
+0.0%     4/10   *  Frequency
+0.0%     4/10   *  BlockFrequency
+0.0%     4/10   *  CumulativeSums
+0.0%     5/10   *  LongestRun
+0.0%     6/10   *  Rank
+0.0%     7/10   *  FFT
+10.0%     2/10   *  ApproximateEntropy
+9.1%     3/10   *  Serial
+14.3%     5/10   *  Frequency
+13.3%     5/10   *  BlockFrequency
+12.5%     2/10   *  CumulativeSums
+11.1%     2/10   *  Runs
+10.5%     5/10   *  LongestRun
+21.7%     1/10   *  ApproximateEntropy
+20.8%     3/10   *  Serial
+
+
+# and the following for a random data set such as /dev/urandom
+90.0%     6/10   *  ApproximateEntropy
+91.3%     6/10   *  ApproximateEntropy
+93.9%     7/10   *  ApproximateEntropy
+93.5%     7/10   *  ApproximateEntropy
+95.6%     7/10   *  ApproximateEntropy
+95.7%     7/10   *  ApproximateEntropy
+95.4%     6/10   *  ApproximateEntropy
+95.2%     6/10   *  ApproximateEntropy
+95.0%     6/10   *  ApproximateEntropy
+94.8%     6/10   *  ApproximateEntropy
+94.6%     6/10   *  ApproximateEntropy
+94.5%     7/10   *  ApproximateEntropy
+

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ Install and Use
 Use git to checkout the current copy of this suite
 From the project directory create the directories that will hold working files during execution and the final test results.
 
-$testhost ~/sards$ experiments/create-dir-script
+> $testhost ~/sards$ experiments/create-dir-script
 
 Modify the makefile as necessary and compile the code
 
 Run the the assess executable passing in a stream of binary data.
-$testhost ~/sards$ cat /dev/urandom | ./assess
+> $testhost ~/sards$ cat /dev/urandom | ./assess
 
 Output produced for a non-random data set, such as for and .mp4 here, will be similar to following:
-0.0%     4/10   *  Frequency
+> 0.0%     4/10   *  Frequency
 0.0%     4/10   *  BlockFrequency
 0.0%     4/10   *  CumulativeSums
 0.0%     5/10   *  LongestRun
@@ -44,7 +44,7 @@ Output produced for a non-random data set, such as for and .mp4 here, will be si
 20.8%     3/10   *  Serial
 
 and the following for a random data set such as /dev/urandom
-90.0%     6/10   *  ApproximateEntropy
+> 90.0%     6/10   *  ApproximateEntropy
 91.3%     6/10   *  ApproximateEntropy
 93.9%     7/10   *  ApproximateEntropy
 93.5%     7/10   *  ApproximateEntropy

--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ Run the the assess executable passing in a stream of binary data.
 > $testhost ~/sards$ cat /dev/urandom | ./assess
 
 Output produced for a non-random data set, such as for and .mp4 here, will be similar to following:
- 0.0%     4/10   *  Frequency
- 0.0%     4/10   *  BlockFrequency
- 0.0%     4/10   *  CumulativeSums
- 0.0%     5/10   *  LongestRun
- 0.0%     6/10   *  Rank
- 0.0%     7/10   *  FFT
- 10.0%     2/10   *  ApproximateEntropy
- 9.1%     3/10   *  Serial
- 14.3%     5/10   *  Frequency
- 13.3%     5/10   *  BlockFrequency
- 12.5%     2/10   *  CumulativeSums
- 11.1%     2/10   *  Runs
- 10.5%     5/10   *  LongestRun
- 21.7%     1/10   *  ApproximateEntropy
- 20.8%     3/10   *  Serial
+> <br>0.0%     4/10   *  Frequency </br>
+> <br>0.0%     4/10   *  BlockFrequency </br>
+> <br>0.0%     4/10   *  CumulativeSums </br>
+> <br>0.0%     5/10   *  LongestRun </br>
+> 0.0%     6/10   *  Rank
+> 0.0%     7/10   *  FFT
+> 10.0%     2/10   *  ApproximateEntropy
+> 9.1%     3/10   *  Serial
+> 14.3%     5/10   *  Frequency
+> 13.3%     5/10   *  BlockFrequency
+> 12.5%     2/10   *  CumulativeSums
+> 11.1%     2/10   *  Runs
+> 10.5%     5/10   *  LongestRun
+> 21.7%     1/10   *  ApproximateEntropy
+> 20.8%     3/10   *  Serial
 
 and the following for a random data set such as /dev/urandom
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,26 @@ Output produced for a non-random data set, such as for and .mp4 here, will be si
 
 and the following for a random data set such as /dev/urandom
  90.0%     6/10   *  ApproximateEntropy
+ 
  91.3%     6/10   *  ApproximateEntropy
+ 
  93.9%     7/10   *  ApproximateEntropy
+ 
  93.5%     7/10   *  ApproximateEntropy
+ 
  95.6%     7/10   *  ApproximateEntropy
+ 
  95.7%     7/10   *  ApproximateEntropy
+ 
  95.4%     6/10   *  ApproximateEntropy
+ 
  95.2%     6/10   *  ApproximateEntropy
+ 
  95.0%     6/10   *  ApproximateEntropy
+ 
  94.8%     6/10   *  ApproximateEntropy
+ 
  94.6%     6/10   *  ApproximateEntropy
+ 
  94.5%     7/10   *  ApproximateEntropy
+ 

--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ Run the the assess executable passing in a stream of binary data.
 
 Output produced for a non-random data set, such as for and .mp4 here, will be similar to following:
 > 0.0%     4/10   *  Frequency
-0.0%     4/10   *  BlockFrequency
-0.0%     4/10   *  CumulativeSums
-0.0%     5/10   *  LongestRun
-0.0%     6/10   *  Rank
-0.0%     7/10   *  FFT
-10.0%     2/10   *  ApproximateEntropy
-9.1%     3/10   *  Serial
-14.3%     5/10   *  Frequency
-13.3%     5/10   *  BlockFrequency
-12.5%     2/10   *  CumulativeSums
-11.1%     2/10   *  Runs
-10.5%     5/10   *  LongestRun
-21.7%     1/10   *  ApproximateEntropy
-20.8%     3/10   *  Serial
+ 0.0%     4/10   *  BlockFrequency
+ 0.0%     4/10   *  CumulativeSums
+ 0.0%     5/10   *  LongestRun
+ 0.0%     6/10   *  Rank
+ 0.0%     7/10   *  FFT
+ 10.0%     2/10   *  ApproximateEntropy
+ 9.1%     3/10   *  Serial
+ 14.3%     5/10   *  Frequency
+ 13.3%     5/10   *  BlockFrequency
+ 12.5%     2/10   *  CumulativeSums
+ 11.1%     2/10   *  Runs
+ 10.5%     5/10   *  LongestRun
+ 21.7%     1/10   *  ApproximateEntropy
+ 20.8%     3/10   *  Serial
 
 and the following for a random data set such as /dev/urandom
 > 90.0%     6/10   *  ApproximateEntropy

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Output produced for a non-random data set, such as for and .mp4 here, will be si
 21.7%     1/10   *  ApproximateEntropy
 20.8%     3/10   *  Serial
 
-
 and the following for a random data set such as /dev/urandom
 90.0%     6/10   *  ApproximateEntropy
 91.3%     6/10   *  ApproximateEntropy
@@ -57,4 +56,3 @@ and the following for a random data set such as /dev/urandom
 94.8%     6/10   *  ApproximateEntropy
 94.6%     6/10   *  ApproximateEntropy
 94.5%     7/10   *  ApproximateEntropy
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project was developed to quickly compare variously generated sets of random
 
 NOTE:  All tests from the battery are executed over the incoming data stream, however, the results from Universal test and the NonOverlapping test are currently being discarded for a couple of reasons.  The Universal test is failing for every data stream passed into the unmodified sts-2.1.2 suite and consequently our modification.  The NonOverlapping test produces multiple evaluations over the same batch of streams and therefore skews our results.
 
-DISCLAIMER!   The original suite was menu driven and not conducive to quick and flexible execution. This work is, to put it mildly a hack job of an apparent hack job, based on the sts-2.1.2 test suite from NIST.  Precedence was given to speed of development not to quality of code.  
+DISCLAIMER!   The original suite was menu driven and not conducive to quick and flexible execution. This work is, to put it mildly, a hack job of an apparent hack job, based on the sts-2.1.2 test suite from NIST.  Precedence was given to speed of development not to quality of code.  
 
 The original sts-2.1.2 suite is available from NIST [here](http://csrc.nist.gov/groups/ST/toolkit/rng/documentation_software.html). 
 The documentation for the analyses performed and the code can be found [here](http://csrc.nist.gov/publications/nistpubs/800-22-rev1a/SP800-22rev1a.pdf).

--- a/README.md
+++ b/README.md
@@ -46,19 +46,15 @@ Output produced for a non-random data set, such as for and .mp4 here, will be si
 and the following for a random data set such as /dev/urandom
 
 > 90.0%     6/10   *  ApproximateEntropy
- 
- 91.3%     6/10   *  ApproximateEntropy
- 93.9%     7/10   *  ApproximateEntropy
- 93.5%     7/10   *  ApproximateEntropy
- 95.6%     7/10   *  ApproximateEntropy
- 95.7%     7/10   *  ApproximateEntropy
- 95.4%     6/10   *  ApproximateEntropy
- 95.2%     6/10   *  ApproximateEntropy
- 95.0%     6/10   *  ApproximateEntropy
- 
- 94.8%     6/10   *  ApproximateEntropy
- 
- 94.6%     6/10   *  ApproximateEntropy
- 
- 94.5%     7/10   *  ApproximateEntropy
+> 91.3%     6/10   *  ApproximateEntropy
+> 93.9%     7/10   *  ApproximateEntropy
+> 93.5%     7/10   *  ApproximateEntropy
+> 95.6%     7/10   *  ApproximateEntropy
+> 95.7%     7/10   *  ApproximateEntropy
+> 95.4%     6/10   *  ApproximateEntropy
+> 95.2%     6/10   *  ApproximateEntropy
+> 95.0%     6/10   *  ApproximateEntropy
+> 94.8%     6/10   *  ApproximateEntropy
+> 94.6%     6/10   *  ApproximateEntropy
+> 94.5%     7/10   *  ApproximateEntropy
  

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Modify the makefile as necessary and compile the code
 Run the the assess executable passing in a stream of binary data.
 > $testhost ~/sards$ cat /dev/urandom | ./assess
 
-Output produced for a non-random data set, such as for and .mp4 here, will be similar to following:
+Output produced for a non-random data set, such as for an .mp4 here, will be similar to following:
 > <br>0.0%     4/10   *  Frequency </br>
 > <br>0.0%     4/10   *  BlockFrequency </br>
 > <br>0.0%     4/10   *  CumulativeSums </br>

--- a/README.md
+++ b/README.md
@@ -44,22 +44,16 @@ Output produced for a non-random data set, such as for and .mp4 here, will be si
  20.8%     3/10   *  Serial
 
 and the following for a random data set such as /dev/urandom
- 90.0%     6/10   *  ApproximateEntropy
+
+> 90.0%     6/10   *  ApproximateEntropy
  
  91.3%     6/10   *  ApproximateEntropy
- 
  93.9%     7/10   *  ApproximateEntropy
- 
  93.5%     7/10   *  ApproximateEntropy
- 
  95.6%     7/10   *  ApproximateEntropy
- 
  95.7%     7/10   *  ApproximateEntropy
- 
  95.4%     6/10   *  ApproximateEntropy
- 
  95.2%     6/10   *  ApproximateEntropy
- 
  95.0%     6/10   *  ApproximateEntropy
  
  94.8%     6/10   *  ApproximateEntropy

--- a/README.md
+++ b/README.md
@@ -31,30 +31,30 @@ Output produced for a non-random data set, such as for and .mp4 here, will be si
 > <br>0.0%     4/10   *  BlockFrequency </br>
 > <br>0.0%     4/10   *  CumulativeSums </br>
 > <br>0.0%     5/10   *  LongestRun </br>
-> 0.0%     6/10   *  Rank
-> 0.0%     7/10   *  FFT
-> 10.0%     2/10   *  ApproximateEntropy
-> 9.1%     3/10   *  Serial
-> 14.3%     5/10   *  Frequency
-> 13.3%     5/10   *  BlockFrequency
-> 12.5%     2/10   *  CumulativeSums
-> 11.1%     2/10   *  Runs
-> 10.5%     5/10   *  LongestRun
-> 21.7%     1/10   *  ApproximateEntropy
-> 20.8%     3/10   *  Serial
+> <br>0.0%     6/10   *  Rank </br>
+> <br>0.0%     7/10   *  FFT </br>
+> <br>10.0%     2/10   *  ApproximateEntropy </br>
+> <br>9.1%     3/10   *  Serial </br>
+> <br>14.3%     5/10   *  Frequency </br>
+> <br>13.3%     5/10   *  BlockFrequency </br>
+> <br>12.5%     2/10   *  CumulativeSums </br>
+> <br>11.1%     2/10   *  Runs </br>
+> <br>10.5%     5/10   *  LongestRun </br>
+> <br>21.7%     1/10   *  ApproximateEntropy </br>
+> <br>20.8%     3/10   *  Serial </br>
 
 and the following for a random data set such as /dev/urandom
 
-> 90.0%     6/10   *  ApproximateEntropy
-> 91.3%     6/10   *  ApproximateEntropy
-> 93.9%     7/10   *  ApproximateEntropy
-> 93.5%     7/10   *  ApproximateEntropy
-> 95.6%     7/10   *  ApproximateEntropy
-> 95.7%     7/10   *  ApproximateEntropy
-> 95.4%     6/10   *  ApproximateEntropy
-> 95.2%     6/10   *  ApproximateEntropy
-> 95.0%     6/10   *  ApproximateEntropy
-> 94.8%     6/10   *  ApproximateEntropy
-> 94.6%     6/10   *  ApproximateEntropy
-> 94.5%     7/10   *  ApproximateEntropy
+> <br>90.0%     6/10   *  ApproximateEntropy </br>
+> <br>91.3%     6/10   *  ApproximateEntropy </br>
+> <br>93.9%     7/10   *  ApproximateEntropy </br>
+> <br>93.5%     7/10   *  ApproximateEntropy </br>
+> <br>95.6%     7/10   *  ApproximateEntropy </br>
+> <br>95.7%     7/10   *  ApproximateEntropy </br>
+> <br>95.4%     6/10   *  ApproximateEntropy </br>
+> <br>95.2%     6/10   *  ApproximateEntropy </br>
+> <br>95.0%     6/10   *  ApproximateEntropy </br>
+> <br>94.8%     6/10   *  ApproximateEntropy </br>
+> <br>94.6%     6/10   *  ApproximateEntropy </br>
+> <br>94.5%     7/10   *  ApproximateEntropy </br>
  

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Run the the assess executable passing in a stream of binary data.
 > $testhost ~/sards$ cat /dev/urandom | ./assess
 
 Output produced for a non-random data set, such as for and .mp4 here, will be similar to following:
-> 0.0%     4/10   *  Frequency
+ 0.0%     4/10   *  Frequency
  0.0%     4/10   *  BlockFrequency
  0.0%     4/10   *  CumulativeSums
  0.0%     5/10   *  LongestRun
@@ -44,15 +44,15 @@ Output produced for a non-random data set, such as for and .mp4 here, will be si
  20.8%     3/10   *  Serial
 
 and the following for a random data set such as /dev/urandom
-> 90.0%     6/10   *  ApproximateEntropy
-91.3%     6/10   *  ApproximateEntropy
-93.9%     7/10   *  ApproximateEntropy
-93.5%     7/10   *  ApproximateEntropy
-95.6%     7/10   *  ApproximateEntropy
-95.7%     7/10   *  ApproximateEntropy
-95.4%     6/10   *  ApproximateEntropy
-95.2%     6/10   *  ApproximateEntropy
-95.0%     6/10   *  ApproximateEntropy
-94.8%     6/10   *  ApproximateEntropy
-94.6%     6/10   *  ApproximateEntropy
-94.5%     7/10   *  ApproximateEntropy
+ 90.0%     6/10   *  ApproximateEntropy
+ 91.3%     6/10   *  ApproximateEntropy
+ 93.9%     7/10   *  ApproximateEntropy
+ 93.5%     7/10   *  ApproximateEntropy
+ 95.6%     7/10   *  ApproximateEntropy
+ 95.7%     7/10   *  ApproximateEntropy
+ 95.4%     6/10   *  ApproximateEntropy
+ 95.2%     6/10   *  ApproximateEntropy
+ 95.0%     6/10   *  ApproximateEntropy
+ 94.8%     6/10   *  ApproximateEntropy
+ 94.6%     6/10   *  ApproximateEntropy
+ 94.5%     7/10   *  ApproximateEntropy

--- a/experiments/create-dir-script
+++ b/experiments/create-dir-script
@@ -1,6 +1,7 @@
 # Create Directory Structure
 
 for dname in AlgorithmTesting BBS CCG G-SHA1 LCG MODEXP MS QCG1 QCG2 XOR ; do 
+        mkdir $dname
 	mkdir $dname/Frequency
 	mkdir $dname/BlockFrequency
 	mkdir $dname/Runs

--- a/experiments/create-dir-script
+++ b/experiments/create-dir-script
@@ -1,20 +1,20 @@
 # Create Directory Structure
 
 for dname in AlgorithmTesting BBS CCG G-SHA1 LCG MODEXP MS QCG1 QCG2 XOR ; do 
-        mkdir $dname
-	mkdir $dname/Frequency
-	mkdir $dname/BlockFrequency
-	mkdir $dname/Runs
-	mkdir $dname/LongestRun
-	mkdir $dname/Rank
-	mkdir $dname/FFT
-	mkdir $dname/NonOverlappingTemplate
-	mkdir $dname/OverlappingTemplate
-	mkdir $dname/Universal
-	mkdir $dname/LinearComplexity
-	mkdir $dname/Serial
-	mkdir $dname/ApproximateEntropy
-	mkdir $dname/CumulativeSums
-	mkdir $dname/RandomExcursions
-	mkdir $dname/RandomExcursionsVariant
+        mkdir experiements/$dname
+	mkdir experiements/$dname/Frequency
+	mkdir experiements/$dname/BlockFrequency
+	mkdir experiements/$dname/Runs
+	mkdir experiements/$dname/LongestRun
+	mkdir experiements/$dname/Rank
+	mkdir experiements/$dname/FFT
+	mkdir experiements/$dname/NonOverlappingTemplate
+	mkdir experiements/$dname/OverlappingTemplate
+	mkdir experiements/$dname/Universal
+	mkdir experiements/$dname/LinearComplexity
+	mkdir experiements/$dname/Serial
+	mkdir experiements/$dname/ApproximateEntropy
+	mkdir experiements/$dname/CumulativeSums
+	mkdir experiements/$dname/RandomExcursions
+	mkdir experiements/$dname/RandomExcursionsVariant
 done


### PR DESCRIPTION
-- added line to create the parent dir

The dirs for test results need to be create in experiment/  before the execution of assess.  We could just add place holders in the myriad of directories as has been done with obj/ but modifying the create-dir-script and having the user execute it before running assess seems like a better solution.
